### PR TITLE
Pin Yarn Classic to fix Cloudflare Pages v3 build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "19": "^0.0.0",
     "@fortawesome/fontawesome-svg-core": "^7.1.0",


### PR DESCRIPTION
## Summary
- Cloudflare Pages v3 build system auto-detects Yarn 4.9.1, which tries to migrate the existing v1 lockfile and fails in immutable mode (`YN0028`)
- Adds `packageManager` field to `package.json` to pin Yarn to 1.22.22, matching the existing lockfile format

## Test plan
- [ ] Verify Cloudflare Pages build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)