### PR TITLE
Homepage: promo vysledku 2026, uzavreni registrace

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,7 @@ import Address from "./Address";
 
 export default function App() {
 
-    const registrationEnabled = true
+    const registrationEnabled = false
 
     const results: string[] = [
         "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2021", "2022", "2023", "2024", "2024-borak", "2025", "2026"

--- a/frontend/src/pages/Homepage/Homepage.tsx
+++ b/frontend/src/pages/Homepage/Homepage.tsx
@@ -16,7 +16,7 @@ export const HomepagePage: FC = () => {
     const navigate = useNavigate();
 
     function handleClickbait() {
-        navigate(Address.registration)
+        navigate(Address.resultsPlaceholder.replace(':year', '2026'))
     }
 
     return (
@@ -52,7 +52,7 @@ export const HomepagePage: FC = () => {
                             variant={'success'}
                             size={"lg"}
                             onClick={() => handleClickbait()}>
-                            Registrace 16. 5. 2026
+                            Výsledky 16. 5. 2026
                         </Button>
                     </p>
                 </Col>
@@ -72,7 +72,7 @@ export const HomepagePage: FC = () => {
 
             <Row id={'bb'} className={'d-none d-sm-none d-md-none d-lg-block'}>
                 <Button variant={"success"} size={'lg'} className={'btn-big mb-3'} onClick={() => handleClickbait()}>
-                    REGISTRACE<br/>
+                    VÝSLEDKY<br/>
                     16. 5. 2026
                 </Button>
             </Row>


### PR DESCRIPTION
## Summary
- Homepage CTA tlacitka (mobile i desktop) odkazuji na vysledky 2026 misto na registraci
- Texty tlacitek: "VYSLEDKY 16. 5. 2026" / "Vysledky 16. 5. 2026"
- Registrace uzavrena (registrationEnabled=false) - na /registrace.html se zobrazi alert "Registrace neni mozna." a formular je disabled

## Test plan
- [x] `yarn build` projde bez chyb
- [x] Homepage desktop ukazuje zelene tlacitko VYSLEDKY 16. 5. 2026 vlevo nahore
- [x] Homepage mobile ukazuje tlacitko Vysledky 16. 5. 2026
- [x] Klik na tlacitko vede na /vysledky-2026.html
- [x] /registrace.html ukazuje cerveny alert "Registrace neni mozna." a tlacitko Provest registraci je disabled