### PR TITLE
Homepage: odkaz na fotky od Dana

### DIFF
--- a/frontend/src/pages/Homepage/Homepage.css
+++ b/frontend/src/pages/Homepage/Homepage.css
@@ -5,3 +5,18 @@
     min-height: 32.5em;
     padding-top: 1.15em;
 }
+
+#bb .photo-link {
+    display: block;
+    width: 380px;
+    text-align: center;
+    color: #1e7e34;
+    font-size: 125%;
+    font-weight: 600;
+    text-decoration: none;
+    margin-bottom: 0.5em;
+}
+
+#bb .photo-link:hover {
+    text-decoration: underline;
+}

--- a/frontend/src/pages/Homepage/Homepage.tsx
+++ b/frontend/src/pages/Homepage/Homepage.tsx
@@ -2,12 +2,12 @@ import {Button, Col, Row} from "react-bootstrap";
 import {useNavigate} from "react-router-dom";
 import './Homepage.css';
 import Address from "../../Address";
-import {Photo} from "../../components/Photo/Photo";
-import photo1 from './images/photo_1.jpg'
-import photo2 from './images/photo_2.jpg'
 import {useDocumentTitle} from "../../hooks/useDocumentTitle";
 import {FC} from "react";
 
+const photoAlbums: { author: string; url: string }[] = [
+    {author: 'Dana', url: 'https://www.rajce.idnes.cz/dao/album/lesempolem-2026'},
+];
 
 export const HomepagePage: FC = () => {
 
@@ -47,26 +47,25 @@ export const HomepagePage: FC = () => {
                     </p>
                 </Col>
                 <Col xs={12}>
-                <p>
+                    <div className={'d-flex flex-wrap gap-2 mb-3'}>
                         <Button
                             variant={'success'}
                             size={"lg"}
                             onClick={() => handleClickbait()}>
                             Výsledky 16. 5. 2026
                         </Button>
-                    </p>
-                </Col>
-
-                <Col xs={12}>
-                    <h2>Fotky ze závodu:</h2>
-                </Col>
-
-                <Col xs={6}>
-                    <Photo src={photo1}/>
-                </Col>
-
-                <Col xs={6}>
-                    <Photo src={photo2}/>
+                        {photoAlbums.map((album) => (
+                            <Button
+                                key={album.url}
+                                variant={'success'}
+                                size={'lg'}
+                                href={album.url}
+                                target={'_blank'}
+                                rel={'noopener noreferrer'}>
+                                Fotky od {album.author}
+                            </Button>
+                        ))}
+                    </div>
                 </Col>
             </Row>
 
@@ -75,6 +74,16 @@ export const HomepagePage: FC = () => {
                     VÝSLEDKY<br/>
                     16. 5. 2026
                 </Button>
+                {photoAlbums.map((album) => (
+                    <a
+                        key={album.url}
+                        href={album.url}
+                        target={'_blank'}
+                        rel={'noopener noreferrer'}
+                        className={'photo-link'}>
+                        Fotky od {album.author} →
+                    </a>
+                ))}
             </Row>
         </>
     );


### PR DESCRIPTION
## Shrnutí
- Přidán odkaz na fotogalerii od Dana (Rajče) na homepage
- Mobil: zelené tlačítko "Fotky od Dana" vedle tlačítka Výsledky
- Desktop: dekorativní textový odkaz "Fotky od Dana →" pod hlavním VÝSLEDKY tlačítkem
- Odstraněny zastaralé embedded fotky (`photo_1.jpg`, `photo_2.jpg`) z mobilní verze
- Struktura `photoAlbums` připravena na přidání dalších autorů jedním řádkem

## Test plan
- [ ] Mobilní šířka: obě tlačítka vedle sebe, na úzkých displejích se zalomí pod sebe
- [ ] Desktopová šířka: textový odkaz pod VÝSLEDKY, otevírá se v nové záložce
- [ ] Cíl odkazu vede na https://www.rajce.idnes.cz/dao/album/lesempolem-2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)