### PR TITLE
Výsledky: odkazy na fotky daného ročníku

### DIFF
--- a/frontend/src/pages/Result/Results.tsx
+++ b/frontend/src/pages/Result/Results.tsx
@@ -1,5 +1,5 @@
 import {FC, useEffect, useState, useMemo} from "react";
-import {Col, Row, Spinner} from "react-bootstrap";
+import {Button, Col, Row, Spinner} from "react-bootstrap";
 import {RaceTable} from "./RaceTable/RaceTable";
 import './Results.css'
 import {useDocumentTitle} from "../../hooks/useDocumentTitle";
@@ -38,10 +38,16 @@ export type Race = {
     results: Result[]
 }
 
+export type PhotoAlbum = {
+    author: string;
+    url: string;
+}
+
 type Competition = {
     title: string;
     year: number;
     races: Race[];
+    photoAlbums?: PhotoAlbum[];
 }
 
 export const Results: FC<Props> = (props) => {
@@ -96,6 +102,23 @@ export const Results: FC<Props> = (props) => {
                     <h1>{competition.title}</h1>
                 </Col>
 
+                {competition.photoAlbums && competition.photoAlbums.length > 0 && (
+                    <Col sm={12}>
+                        <div className={'d-flex flex-wrap gap-2 mb-3'}>
+                            {competition.photoAlbums.map((album) => (
+                                <Button
+                                    key={album.url}
+                                    variant={'success'}
+                                    size={'lg'}
+                                    href={album.url}
+                                    target={'_blank'}
+                                    rel={'noopener noreferrer'}>
+                                    Fotky od {album.author}
+                                </Button>
+                            ))}
+                        </div>
+                    </Col>
+                )}
 
                 {showSpinner()}
 

--- a/frontend/src/pages/Result/results/2015.json
+++ b/frontend/src/pages/Result/results/2015.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2015",
   "year": 2015,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2015"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2019.json
+++ b/frontend/src/pages/Result/results/2019.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2019",
   "year": 2019,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2019"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2021.json
+++ b/frontend/src/pages/Result/results/2021.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2021",
   "year": 2021,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-mcr-v-ultratrailu-2021"
+    }
+  ],
   "races": [
     {
       "title": "MČR ultramaraton",

--- a/frontend/src/pages/Result/results/2022.json
+++ b/frontend/src/pages/Result/results/2022.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2022",
   "year": 2022,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2022"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",

--- a/frontend/src/pages/Result/results/2023.json
+++ b/frontend/src/pages/Result/results/2023.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2023",
   "year": 2022,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu"
+    }
+  ],
   "races": [
     {
       "title": "MČR ultramaraton",

--- a/frontend/src/pages/Result/results/2025.json
+++ b/frontend/src/pages/Result/results/2025.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2025",
   "year": 2015,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesem-borem-2025"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",

--- a/frontend/src/pages/Result/results/2026.json
+++ b/frontend/src/pages/Result/results/2026.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2026",
   "year": 2026,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2026"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",


### PR DESCRIPTION
## Shrnutí
- Volitelné pole `photoAlbums?: { author, url }[]` v každém `results/{year}.json`
- Pokud ročník fotky má, zobrazí se zelená tlačítka „Fotky od {autor}" pod nadpisem stránky výsledků
- Ročníky bez fotek vypadají beze změny (žádná prázdná mezera)
- Další ročníky/autory stačí doplnit do příslušného JSONu, žádné kódové změny

## Data
Doplněny odkazy na fotogalerie Daniela Orálka (Rajče):

| Rok | Album |
|---|---|
| 2026 | [Lesempolem 2026](https://www.rajce.idnes.cz/dao/album/lesempolem-2026) |
| 2025 | [Lesem Borem 2025](https://www.rajce.idnes.cz/dao/album/lesem-borem-2025) |
| 2023 | [Lesempolem 2023 – MČR v ultratrailu](https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu) |
| 2022 | [Lesempolem 2022](https://www.rajce.idnes.cz/dao/album/lesempolem-2022) |
| 2021 | [Lesempolem – MČR v ultratrailu 2021](https://www.rajce.idnes.cz/dao/album/lesempolem-mcr-v-ultratrailu-2021) |
| 2019 | [Lesempolem 2019](https://www.rajce.idnes.cz/dao/album/lesempolem-2019) |
| 2015 | [Lesempolem 2015](https://www.rajce.idnes.cz/dao/album/lesempolem-2015) |

Ročníky 2013, 2014, 2016, 2017, 2018, 2020, 2024 — fotky se na Danově Rajčeti najít nepodařilo.

## Test plan
- [ ] `/vysledky-2026.html`, `/vysledky-2025.html`, `/vysledky-2023.html`, … zobrazí tlačítko „Fotky od Dana"
- [ ] Ročníky bez fotek (např. 2013, 2014, 2024) — stránka beze změny, žádná prázdná mezera
- [ ] Klik otevře album v nové záložce

🤖 Generated with [Claude Code](https://claude.com/claude-code)