### PR TITLE
Výsledky: fotky od Dana pro starší ročníky

### DIFF
--- a/frontend/src/pages/Result/results/2015.json
+++ b/frontend/src/pages/Result/results/2015.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2015",
   "year": 2015,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2015"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2019.json
+++ b/frontend/src/pages/Result/results/2019.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2019",
   "year": 2019,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2019"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2021.json
+++ b/frontend/src/pages/Result/results/2021.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2021",
   "year": 2021,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-mcr-v-ultratrailu-2021"
+    }
+  ],
   "races": [
     {
       "title": "MČR ultramaraton",

--- a/frontend/src/pages/Result/results/2022.json
+++ b/frontend/src/pages/Result/results/2022.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2022",
   "year": 2022,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2022"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",

--- a/frontend/src/pages/Result/results/2023.json
+++ b/frontend/src/pages/Result/results/2023.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2023",
   "year": 2022,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu"
+    }
+  ],
   "races": [
     {
       "title": "MČR ultramaraton",

--- a/frontend/src/pages/Result/results/2025.json
+++ b/frontend/src/pages/Result/results/2025.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu v roce 2025",
   "year": 2015,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/lesem-borem-2025"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",


### PR DESCRIPTION
## Shrnutí
Doplnění odkazů na fotogalerie Daniela Orálka (Rajče) pro starší ročníky:

| Rok | Album |
|---|---|
| 2025 | [Lesem Borem 2025](https://www.rajce.idnes.cz/dao/album/lesem-borem-2025) |
| 2023 | [Lesempolem 2023 – MČR v ultratrailu](https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu) |
| 2022 | [Lesempolem 2022](https://www.rajce.idnes.cz/dao/album/lesempolem-2022) |
| 2021 | [Lesempolem – MČR v ultratrailu 2021](https://www.rajce.idnes.cz/dao/album/lesempolem-mcr-v-ultratrailu-2021) |
| 2019 | [Lesempolem 2019](https://www.rajce.idnes.cz/dao/album/lesempolem-2019) |
| 2015 | [Lesempolem 2015](https://www.rajce.idnes.cz/dao/album/lesempolem-2015) |

Ročníky 2013, 2014, 2016, 2017, 2018, 2020, 2024 — fotky se na Danově Rajčeti najít nepodařilo.

## Závislost
Tato PR upravuje pouze JSON data. Tlačítka se na stránkách výsledků zobrazí až po mergi **#18** (frontend feature pro vykreslení `photoAlbums`). Bez něj se data ignorují — aplikace běží beze změny.

## Test plan
- [ ] Po mergi #18: `/vysledky-2025.html`, `/vysledky-2023.html`, … zobrazí tlačítko „Fotky od Dana"
- [ ] Roky bez fotek (2013, 2014, 2016, 2017, 2018, 2020, 2024) — stránka beze změny
- [ ] JSON syntax validní (ověřeno `python3 -c "import json; json.load(...)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)