### PR TITLE
Výsledky: doplnění fotek z Rajče pro ročníky 2013–2024 a 2026

### DIFF
--- a/frontend/src/pages/Homepage/Homepage.tsx
+++ b/frontend/src/pages/Homepage/Homepage.tsx
@@ -6,7 +6,7 @@ import {useDocumentTitle} from "../../hooks/useDocumentTitle";
 import {FC} from "react";
 
 const photoAlbums: { author: string; url: string }[] = [
-    {author: 'Dana', url: 'https://www.rajce.idnes.cz/dao/album/lesempolem-2026'},
+    {author: 'Dan Orálek', url: 'https://www.rajce.idnes.cz/dao/album/lesempolem-2026'},
 ];
 
 export const HomepagePage: FC = () => {

--- a/frontend/src/pages/Result/Results.tsx
+++ b/frontend/src/pages/Result/Results.tsx
@@ -1,5 +1,7 @@
 import {FC, useEffect, useState, useMemo} from "react";
 import {Button, Col, Row, Spinner} from "react-bootstrap";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faCamera} from "@fortawesome/free-solid-svg-icons";
 import {RaceTable} from "./RaceTable/RaceTable";
 import './Results.css'
 import {useDocumentTitle} from "../../hooks/useDocumentTitle";
@@ -113,7 +115,8 @@ export const Results: FC<Props> = (props) => {
                                     href={album.url}
                                     target={'_blank'}
                                     rel={'noopener noreferrer'}>
-                                    Fotky od {album.author}
+                                    <FontAwesomeIcon icon={faCamera} className={'me-2'}/>
+                                    {album.author}
                                 </Button>
                             ))}
                         </div>

--- a/frontend/src/pages/Result/results/2013.json
+++ b/frontend/src/pages/Result/results/2013.json
@@ -1,6 +1,16 @@
 {
   "title": "Výsledky závodu v roce 2013",
   "year": 2013,
+  "photoAlbums": [
+    {
+      "author": "mag80",
+      "url": "https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-15-6-2013"
+    },
+    {
+      "author": "vileda",
+      "url": "https://www.rajce.idnes.cz/vileda/album/lesempolem-zavody-veselice"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2014.json
+++ b/frontend/src/pages/Result/results/2014.json
@@ -1,6 +1,20 @@
 {
   "title": "Výsledky závodu v roce 2014",
   "year": 2014,
+  "photoAlbums": [
+    {
+      "author": "Nikol9",
+      "url": "https://www.rajce.idnes.cz/nikol9/album/lesempolem-veselice-14-6-2014"
+    },
+    {
+      "author": "simumar",
+      "url": "https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-14-6-2014"
+    },
+    {
+      "author": "Věra",
+      "url": "https://www.rajce.idnes.cz/verkaal/album/lesempolem-veselice-14-6-2014"
+    }
+  ],
   "races": [
     {
       "distance": 10250,

--- a/frontend/src/pages/Result/results/2015.json
+++ b/frontend/src/pages/Result/results/2015.json
@@ -5,6 +5,14 @@
     {
       "author": "Dana",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2015"
+    },
+    {
+      "author": "Nikol9",
+      "url": "https://www.rajce.idnes.cz/nikol9/album/lesempolem-13-6-2015"
+    },
+    {
+      "author": "simumar",
+      "url": "https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-13-6-2015"
     }
   ],
   "races": [

--- a/frontend/src/pages/Result/results/2015.json
+++ b/frontend/src/pages/Result/results/2015.json
@@ -3,7 +3,7 @@
   "year": 2015,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2015"
     },
     {

--- a/frontend/src/pages/Result/results/2016.json
+++ b/frontend/src/pages/Result/results/2016.json
@@ -1,6 +1,16 @@
 {
   "title": "Výsledky závodu v roce 2016",
   "year": 2016,
+  "photoAlbums": [
+    {
+      "author": "mag80",
+      "url": "https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-18-6-2016"
+    },
+    {
+      "author": "simumar",
+      "url": "https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-18-6-2016"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2017.json
+++ b/frontend/src/pages/Result/results/2017.json
@@ -1,6 +1,24 @@
 {
   "title": "Výsledky závodu v roce 2017",
   "year": 2017,
+  "photoAlbums": [
+    {
+      "author": "Lenkatopka",
+      "url": "https://www.rajce.idnes.cz/lenkatopka/album/10-6-2017-lesempolem-veselice"
+    },
+    {
+      "author": "mag80",
+      "url": "https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-10-6-2017"
+    },
+    {
+      "author": "Nikol9",
+      "url": "https://www.rajce.idnes.cz/nikol9/album/lesempolem-10-6-2017"
+    },
+    {
+      "author": "simumar",
+      "url": "https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-10-6-2017"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2018.json
+++ b/frontend/src/pages/Result/results/2018.json
@@ -1,6 +1,20 @@
 {
   "title": "Výsledky závodu v roce 2018",
   "year": 2018,
+  "photoAlbums": [
+    {
+      "author": "AK Blansko Dvorská",
+      "url": "https://www.rajce.idnes.cz/akbd/album/lesempolem-ve-veselici-16-6-2018"
+    },
+    {
+      "author": "OBL Blansko",
+      "url": "https://www.rajce.idnes.cz/okresni-bezecka-liga/album/16-6-2018-lesempolem-veselice"
+    },
+    {
+      "author": "Perun Team Blansko",
+      "url": "https://www.rajce.idnes.cz/perunteamblansko/album/2018-06-16-obl-lesempolem"
+    }
+  ],
   "races": [
     {
       "distance": 10000,

--- a/frontend/src/pages/Result/results/2019.json
+++ b/frontend/src/pages/Result/results/2019.json
@@ -3,7 +3,7 @@
   "year": 2019,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2019"
     },
     {

--- a/frontend/src/pages/Result/results/2019.json
+++ b/frontend/src/pages/Result/results/2019.json
@@ -5,6 +5,10 @@
     {
       "author": "Dana",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2019"
+    },
+    {
+      "author": "Perun Team Blansko",
+      "url": "https://www.rajce.idnes.cz/perunteamblansko/album/2019-06-15-obl-lesempolem"
     }
   ],
   "races": [

--- a/frontend/src/pages/Result/results/2021.json
+++ b/frontend/src/pages/Result/results/2021.json
@@ -3,7 +3,7 @@
   "year": 2021,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-mcr-v-ultratrailu-2021"
     }
   ],

--- a/frontend/src/pages/Result/results/2022.json
+++ b/frontend/src/pages/Result/results/2022.json
@@ -3,7 +3,7 @@
   "year": 2022,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2022"
     },
     {

--- a/frontend/src/pages/Result/results/2022.json
+++ b/frontend/src/pages/Result/results/2022.json
@@ -5,6 +5,10 @@
     {
       "author": "Dana",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2022"
+    },
+    {
+      "author": "OBL Blansko",
+      "url": "https://www.rajce.idnes.cz/okresni-bezecka-liga/album/lesempolem-11-6-2022"
     }
   ],
   "races": [

--- a/frontend/src/pages/Result/results/2023.json
+++ b/frontend/src/pages/Result/results/2023.json
@@ -5,6 +5,10 @@
     {
       "author": "Dana",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu"
+    },
+    {
+      "author": "jivy74",
+      "url": "https://www.rajce.idnes.cz/jivy74/album/lesempolem-10-6-2023"
     }
   ],
   "races": [

--- a/frontend/src/pages/Result/results/2023.json
+++ b/frontend/src/pages/Result/results/2023.json
@@ -3,7 +3,7 @@
   "year": 2022,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2023-mcr-v-ultratrailu"
     },
     {

--- a/frontend/src/pages/Result/results/2024-borak.json
+++ b/frontend/src/pages/Result/results/2024-borak.json
@@ -1,6 +1,12 @@
 {
   "title": "Výsledky závodu Borák za tvarůžkem v roce 2024",
   "year": 2024,
+  "photoAlbums": [
+    {
+      "author": "Dana",
+      "url": "https://www.rajce.idnes.cz/dao/album/borak-ve-veselici-11-5-2024"
+    }
+  ],
   "races": [
     {
       "title": "Ultramaraton",

--- a/frontend/src/pages/Result/results/2024-borak.json
+++ b/frontend/src/pages/Result/results/2024-borak.json
@@ -3,7 +3,7 @@
   "year": 2024,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/borak-ve-veselici-11-5-2024"
     }
   ],

--- a/frontend/src/pages/Result/results/2025.json
+++ b/frontend/src/pages/Result/results/2025.json
@@ -3,7 +3,7 @@
   "year": 2015,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesem-borem-2025"
     }
   ],

--- a/frontend/src/pages/Result/results/2026.json
+++ b/frontend/src/pages/Result/results/2026.json
@@ -3,7 +3,7 @@
   "year": 2026,
   "photoAlbums": [
     {
-      "author": "Dana",
+      "author": "Dan Orálek",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2026"
     },
     {

--- a/frontend/src/pages/Result/results/2026.json
+++ b/frontend/src/pages/Result/results/2026.json
@@ -5,6 +5,10 @@
     {
       "author": "Dana",
       "url": "https://www.rajce.idnes.cz/dao/album/lesempolem-2026"
+    },
+    {
+      "author": "Dagmar Kuncová",
+      "url": "https://www.rajce.idnes.cz/okresni-bezecka-liga/album/lesempolem-za-tvaruzkem-16-5-2026-autor-dagmar-kuncova"
     }
   ],
   "races": [


### PR DESCRIPTION
## Souhrn

Doplnil jsem do JSONů s výsledky další alba z **rajce.idnes.cz** od dalších fotografů (kromě Dany, která už tam byla). Alba jsem našel přes vyhledávání na Rajči a ověřil názvy/data z titulků alb.

## Přidaná alba podle ročníků

| Rok | Autor | Album |
|---|---|---|
| 2013 | mag80 | [lesempolem-veselice-15-6-2013](https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-15-6-2013) |
| 2013 | vileda | [lesempolem-zavody-veselice](https://www.rajce.idnes.cz/vileda/album/lesempolem-zavody-veselice) (EXIF data: 15. 6. 2013) |
| 2014 | Nikol9 | [lesempolem-veselice-14-6-2014](https://www.rajce.idnes.cz/nikol9/album/lesempolem-veselice-14-6-2014) |
| 2014 | simumar | [lesempolem-veselice-14-6-2014](https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-14-6-2014) |
| 2014 | Věra | [lesempolem-veselice-14-6-2014](https://www.rajce.idnes.cz/verkaal/album/lesempolem-veselice-14-6-2014) |
| 2015 | Nikol9 | [lesempolem-13-6-2015](https://www.rajce.idnes.cz/nikol9/album/lesempolem-13-6-2015) |
| 2015 | simumar | [lesempolem-veselice-13-6-2015](https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-13-6-2015) |
| 2016 | mag80 | [lesempolem-veselice-18-6-2016](https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-18-6-2016) |
| 2016 | simumar | [lesempolem-veselice-18-6-2016](https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-18-6-2016) |
| 2017 | Lenkatopka | [10-6-2017-lesempolem-veselice](https://www.rajce.idnes.cz/lenkatopka/album/10-6-2017-lesempolem-veselice) |
| 2017 | mag80 | [lesempolem-veselice-10-6-2017](https://www.rajce.idnes.cz/mag80/album/lesempolem-veselice-10-6-2017) |
| 2017 | Nikol9 | [lesempolem-10-6-2017](https://www.rajce.idnes.cz/nikol9/album/lesempolem-10-6-2017) |
| 2017 | simumar | [lesempolem-veselice-10-6-2017](https://www.rajce.idnes.cz/simumar/album/lesempolem-veselice-10-6-2017) |
| 2018 | AK Blansko Dvorská | [lesempolem-ve-veselici-16-6-2018](https://www.rajce.idnes.cz/akbd/album/lesempolem-ve-veselici-16-6-2018) |
| 2018 | OBL Blansko | [16-6-2018-lesempolem-veselice](https://www.rajce.idnes.cz/okresni-bezecka-liga/album/16-6-2018-lesempolem-veselice) |
| 2018 | Perun Team Blansko | [2018-06-16-obl-lesempolem](https://www.rajce.idnes.cz/perunteamblansko/album/2018-06-16-obl-lesempolem) |
| 2019 | Perun Team Blansko | [2019-06-15-obl-lesempolem](https://www.rajce.idnes.cz/perunteamblansko/album/2019-06-15-obl-lesempolem) |
| 2022 | OBL Blansko | [lesempolem-11-6-2022](https://www.rajce.idnes.cz/okresni-bezecka-liga/album/lesempolem-11-6-2022) |
| 2023 | jivy74 | [lesempolem-10-6-2023](https://www.rajce.idnes.cz/jivy74/album/lesempolem-10-6-2023) |
| 2024 Borák | Dana | [borak-ve-veselici-11-5-2024](https://www.rajce.idnes.cz/dao/album/borak-ve-veselici-11-5-2024) |
| 2026 | Dagmar Kuncová | [lesempolem-za-tvaruzkem-16-5-2026-autor-dagmar-kuncova](https://www.rajce.idnes.cz/okresni-bezecka-liga/album/lesempolem-za-tvaruzkem-16-5-2026-autor-dagmar-kuncova) |

## Test plan
- [ ] `yarn start` v `frontend/` a projít stránky `/vysledky-2013.html` až `/vysledky-2026.html`, na každé ověřit, že se zobrazují nová tlačítka „Fotky od …".
- [ ] Kliknout na pár nových odkazů a ověřit, že vedou na očekávaná alba.
- [ ] `yarn build` proběhne bez chyb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)